### PR TITLE
Add updated instructions for compiling Python from source for M4

### DIFF
--- a/Modules/Module_4/Project_Exercise/hints.md
+++ b/Modules/Module_4/Project_Exercise/hints.md
@@ -1,0 +1,31 @@
+# Module 4 Project Exercise Hints
+
+<details markdown="1">
+<summary markdown="1">
+How can I install a specific version of Python?
+</summary>
+
+Here are example instructions to install Python from source in case you need a more recent version than that provided by yum. Your playbook should check whether Python is already installed before running these commands.
+
+### 1. Install Dependencies
+```sh
+sudo yum update -y
+sudo yum groupinstall "Development Tools" -y
+# If installing a version of Python < 3.10, then use openssl-devel in place of openssl11-devel
+sudo yum install libffi-devel bzip2-devel wget openssl11-devel -y
+```
+
+### 2. Download, unzip, cd
+```sh
+wget https://www.python.org/ftp/python/3.10.0/Python-3.10.2.tgz
+tar -xf Python-3.10.2.tgz
+cd Python-3.10.2/
+```
+
+### 3. Build and install it
+```sh
+sudo ./configure --enable-optimizations
+sudo make -j $(nproc)
+sudo make altinstall # or "sudo make install" to override existing Python
+```
+</details>

--- a/Modules/Module_4/Project_Exercise/hints.md
+++ b/Modules/Module_4/Project_Exercise/hints.md
@@ -17,7 +17,7 @@ sudo yum install libffi-devel bzip2-devel wget openssl11-devel -y
 
 ### 2. Download, unzip, cd
 ```sh
-wget https://www.python.org/ftp/python/3.10.0/Python-3.10.2.tgz
+wget https://www.python.org/ftp/python/3.10.2/Python-3.10.2.tgz
 tar -xf Python-3.10.2.tgz
 cd Python-3.10.2/
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Modules:
   * [Project Exercise hints](Modules/Module_2/Project_Exercise/hints.md)
 * Module 3
   * [Project Exercise code samples](Modules/Module_3/Project_Exercise/code_samples.md)
+* Module 4
+  * [Project Exercise hints](Modules/Module_4/Project_Exercise/hints.md)
 * Module 5
   * [Testing in Docker](Modules/Module_5/Project_Exercise/testing_in_docker.md)
 * Module 9


### PR DESCRIPTION
Saw an issue recently with a learner who'd followed the provided instructions in the Readme docs, and we managed to fix it primarily by [following this SO thread](https://stackoverflow.com/questions/69692703/compiling-python-3-10-at-amazon-linux-2) and also we had to switch the `make` command to sudo
I'll also accompany this with a PR to update the PDF to include a link to this page rather than having the instructions built in, since this is no doubt going to keep changing in future