### PR TITLE
Add contact us page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ### Tips & Extras
 
-Are you stuck on a particular exercise or using a particular tool, or do you just want to read up a bit further? Here are a collection of issues that learners have experienced to help get you unstuck, combined with some starting points for more advanced topics. If you're still having issues, other great avenues to explore are reaching out to other members of your cohort who are likely to have seen similar issues, or to the tutors.
+Are you stuck on a particular exercise or using a particular tool, or do you just want to read up a bit further? Here are a collection of issues that learners have experienced to help get you unstuck, combined with some starting points for more advanced topics. If you're still having issues, other great avenues to explore are reaching out to other members of your cohort who are likely to have seen similar issues, or to the trainers. 
+
+See [this contact page](./contact_us.md) for how best to reach the trainers.
 
 This documentation is living - it will need to grow as we and you learn new things, or the course changes. If you think anything is out of date, then feel free to let us know, or even better raise a pull request & suggest an improvement directly! See [raising a PR](raising_a_pr.md) for more information.
 

--- a/contact_us.md
+++ b/contact_us.md
@@ -1,0 +1,17 @@
+---
+title: "Contact Us"
+description: How to reach out for extra support
+---
+
+Do not hesitate to reach out if you have any questions/concerns. You can reach us in a few ways:
+
+1) Slack. This is the quickest way to get a response. Send a message to your cohort's channel if you think others may be interested, or send a message directly to the trainers.
+
+2) Email. Use the team address (DevOpsDelivery@corndel.com) and one of the trainers will respond. 
+
+3) Video call. If you are facing a complex issue, so that a question and answer over text would not be effective, use these links to book a 30 minute call with one of the trainers. We ask you to try not to book more than one call per week unless you are trying to catch up on the course material. 
+
+* https://calendly.com/jack-mead/devops-1-to-1
+* https://calendly.com/alexander-jones-2/devops-1-to-1
+* https://calendly.com/ben-ramchandani/devops-1-to-1
+* https://calendly.com/josh-powell-1/support-call


### PR DESCRIPTION
So we don't need to list calendly links on Slack anymore