### PR TITLE
Fix an incorrect FAQ link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Modules:
   * [Project Exercise hints](Modules/Module_5/Project_Exercise/hints.md)
   * [Testing in Docker](Modules/Module_5/Project_Exercise/testing_in_docker.md)
 * Module 7 - Continuous Delivery
-  * [Project Exercise hints](Modules/Module_8/Project_Exercise/hints.md)
+  * [Project Exercise hints](Modules/Module_7/Project_Exercise/hints.md)
 * Module 8 - Continuous Delivery
   * [Project Exercise hints](Modules/Module_8/Project_Exercise/hints.md)
 * Module 9 - Tooling & Cloud Infrastructure


### PR DESCRIPTION
Caught by a learner - M7's link pointed to M8