### PR TITLE
Fix the local Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
     - name: Spin up container
       run: docker compose up --build --detach
     - name: Check it's alive
-      run: curl --fail http://localhost:4000
+      run: sleep 5 && curl --fail http://localhost:4000
     - name: Tear down containers
       run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: FAQs Check Local Docker Image Works
+on: [push, pull_request]
+
+jobs:
+  check-build:
+    name: Check Build Succeeds
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Spin up container
+      run: docker compose up --build --detach
+    - name: Check it's alive
+      run: curl --fail http://localhost:4000
+    - name: Tear down containers
+      run: docker compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu
-
-RUN apt-get update && apt-get install ruby-full build-essential -y
+FROM ruby:2.7-alpine
+RUN apk update && apk add alpine-sdk
+RUN gem update --system
 RUN gem install jekyll bundler
 WORKDIR /srv/jekyll
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
Locally I was seeing issues running the site through Docker, I think due to a change to Ruby 3 at some stage. I've adapted here to use Alpine as:
A) It is hopefully a chunk smaller and thus quicker to build!
B) It was easier to install Ruby 2.7 on it

As a bonus, I've added a quick CI script to try flag if that breaks again in future